### PR TITLE
update toggle UI via updateToggleIconUI on disconnect

### DIFF
--- a/src/runtime/panel/app/index.ts
+++ b/src/runtime/panel/app/index.ts
@@ -10,7 +10,6 @@ import { STATUS } from '@panel/view/status';
 import { renderList, updateStatusUI, updateToggleIconUI } from '@panel/view/ui';
 
 const toggleBtn = document.getElementById('toggle-select') as HTMLButtonElement;
-const toggleLabel = document.getElementById('toggle-label') as HTMLSpanElement;
 const clearBtn = document.getElementById('clear') as HTMLButtonElement;
 const captureBtn = document.getElementById('capture') as HTMLButtonElement;
 
@@ -40,7 +39,7 @@ async function main() {
   conn.onDisconnect(() => {
     updateStatusUI(STATUS.DISCONNECTED);
     selectionEnabled = false;
-    toggleLabel.textContent = i18n.get('toggle_off');
+    updateToggleIconUI(selectionEnabled);
   });
 
   // Receives messages from Content → Panel.


### PR DESCRIPTION
When the side panel was active and the user navigated to a different page, an error occurred during the `onDisconnect` event because `toggleLabel` was `null`.
This happened when attempting to directly update `toggleLabel.textContent`.

## Error Details

```
Error in event handler: TypeError: Cannot set properties of null (setting 'textContent')
```

```
    conn.onDisconnect(() => {
        updateStatusUI(STATUS.DISCONNECTED);
        selectionEnabled = false;
        toggleLabel.textContent = i18n.get('toggle_off'); // Error occurred here
    });
```

## Changes
Replaced the direct `toggleLabel.textContent` update with a call to `updateToggleIconUI`.