### PR TITLE
Translucent highlight of content elements on side-panel item hover

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default tseslint.config(
           ['^\\./(?!.*/$).*', '^\\./?$'],
         ],
       }],
+      'no-console': ['error', { allow: ['warn', 'error', 'debug'] }],
     },
   },
 

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -5,7 +5,7 @@ const P2C = {
   TOGGLE_SELECT: 'TOGGLE_SELECT',
   RENDER: 'RENDER',
   CLEAR: 'CLEAR',
-  GET_STATE: 'GET_STATE',
+  HOVER: 'HOVER',
 } as const;
 
 const C2P = {
@@ -28,7 +28,7 @@ export type PanelToContent =
   | { type: typeof P2C.TOGGLE_SELECT; payload: { enabled: boolean } }
   | { type: typeof P2C.RENDER; payload: { items: ScreenItem[] } }
   | { type: typeof P2C.CLEAR }
-  | { type: typeof P2C.GET_STATE };
+  | { type: typeof P2C.HOVER; payload: { id: number | null } };
 
 export type ContentToPanel = { type: typeof C2P.SELECTED; payload: { anchors: Anchor[] } };
 

--- a/src/runtime/content/main.ts
+++ b/src/runtime/content/main.ts
@@ -3,7 +3,13 @@ import { MSG_TYPE, type PanelToContent } from '@common/messages';
 import type { ScreenItem } from '@common/types';
 
 import { buildCssAnchor } from './anchor';
-import { bindCssSelectorMap, clearOverlay, mountOverlay, renderItems } from './overlay';
+import {
+  bindCssSelectorMap,
+  clearOverlay,
+  highlightOverlay,
+  mountOverlay,
+  renderItems,
+} from './overlay';
 import { Selector } from './selector';
 
 const selection = new Selector(onPick);
@@ -36,7 +42,8 @@ chrome.runtime.onConnect.addListener(async (p) => {
       case MSG_TYPE.CLEAR:
         await clearOverlay();
         break;
-      case MSG_TYPE.GET_STATE:
+      case MSG_TYPE.HOVER:
+        await highlightOverlay(msg.payload.id);
         break;
     }
   });

--- a/src/runtime/content/overlay.ts
+++ b/src/runtime/content/overlay.ts
@@ -13,6 +13,8 @@ const tracked = new Map<number, Tracked>();
 
 let rafPending = false;
 
+let hoveredId: number | null = null;
+
 /**
  * Mounts the on-page overlay (Shadow DOM) that draws selection boxes.
  * Also sets up scroll/resize listeners to reschedule position updates.
@@ -108,6 +110,25 @@ export async function clearOverlay() {
   if (!rootEl) return;
   rootEl.innerHTML = '';
   tracked.clear();
+}
+
+/**
+ * Switches the hover highlight to the specified overlay.
+ *
+ * @param id - Overlay identifier to highlight, or `null` to clear the highlight.
+ */
+export async function highlightOverlay(id: number | null) {
+  if (id === hoveredId) return;
+
+  const prev = hoveredId;
+  hoveredId = id;
+
+  if (prev != null) {
+    tracked.get(prev)?.boxEl.classList.remove('is-hovered');
+  }
+  if (id != null) {
+    tracked.get(id)?.boxEl.classList.add('is-hovered');
+  }
 }
 
 /**

--- a/src/runtime/panel/app/actions.ts
+++ b/src/runtime/panel/app/actions.ts
@@ -37,5 +37,7 @@ export type Action =
   | { type: ActionType.ITEM_SELECTION_CHANGED; id: number; isCheck: boolean }
   | { type: ActionType.ITEM_SELECTION_CHANGED; group: string; isCheck: boolean }
   | { type: ActionType.ITEM_SELECTION_CHANGED; allCheck: boolean }
+  | { type: ActionType.ITEM_HOVER_IN; id: number }
+  | { type: ActionType.ITEM_HOVER_OUT }
   | { type: ActionType.PORT_DISCONNECTED }
   | { type: ActionType.CLOSE_PANEL_REQUESTED; tabId?: number };

--- a/src/runtime/panel/app/update.ts
+++ b/src/runtime/panel/app/update.ts
@@ -11,6 +11,7 @@ export type Effect =
   | { kind: EffectType.RENDER_CONTENT; items: ScreenItem[] }
   | { kind: EffectType.TOGGLE_SELECT_ON_CONTENT; enabled: boolean }
   | { kind: EffectType.CLEAR_CONTENT }
+  | { kind: EffectType.HOVER; id: number | null }
   | {
       kind: EffectType.CAPTURE;
       payload: {
@@ -218,6 +219,18 @@ export function update(model: Model, action: Action): { model: Model; effects: E
         };
       }
     }
+
+    case ActionType.ITEM_HOVER_IN:
+      return {
+        model,
+        effects: [{ kind: EffectType.HOVER, id: action.id }],
+      };
+
+    case ActionType.ITEM_HOVER_OUT:
+      return {
+        model,
+        effects: [{ kind: EffectType.HOVER, id: null }],
+      };
 
     case ActionType.PORT_DISCONNECTED:
       return {

--- a/src/runtime/panel/controller/panel_controller.ts
+++ b/src/runtime/panel/controller/panel_controller.ts
@@ -125,6 +125,12 @@ export class PanelController {
           | { allCheck: boolean },
       ) => this.dispatch({ type: ActionType.ITEM_SELECTION_CHANGED, ...payload }),
     );
+    this.view.on(UIEventType.ITEM_HOVER_IN, ({ id }) =>
+      this.dispatch({ type: ActionType.ITEM_HOVER_IN, id }),
+    );
+    this.view.on(UIEventType.ITEM_HOVER_OUT, () =>
+      this.dispatch({ type: ActionType.ITEM_HOVER_OUT }),
+    );
 
     this.view.render(this.model);
   }
@@ -147,6 +153,9 @@ export class PanelController {
           break;
         case EffectType.CLEAR_CONTENT:
           await this.conn?.api.clear();
+          break;
+        case EffectType.HOVER:
+          await this.conn?.api.hover(fx.id);
           break;
         case EffectType.CLEAR_STATE:
           await setState(this.model.pageKey, {

--- a/src/runtime/panel/messaging/api.ts
+++ b/src/runtime/panel/messaging/api.ts
@@ -49,6 +49,16 @@ export class PanelApi {
   }
 
   /**
+   * Set the hovered item and request a transient highlight on Content.
+   * Pass `null` to clear the current hover highlight.
+   *
+   * @param id - Target item ID, or `null` to clear.
+   */
+  hover(id: number | null) {
+    return this.send({ type: MSG_TYPE.HOVER, payload: { id } });
+  }
+
+  /**
    * Performs a connectivity health check (round-trip).
    * Sent as a request expecting a reply.
    *

--- a/src/runtime/panel/types/action_types.ts
+++ b/src/runtime/panel/types/action_types.ts
@@ -79,4 +79,10 @@ export enum ActionType {
 
   /** Emitted when an item's edit-selection checkbox changes state */
   ITEM_SELECTION_CHANGED = 'ITEM_SELECTION_CHANGED',
+
+  /** Start item hover */
+  ITEM_HOVER_IN = 'ITEM_HOVER_IN',
+
+  /** End item hover */
+  ITEM_HOVER_OUT = 'ITEM_HOVER_OUT',
 }

--- a/src/runtime/panel/types/effect_types.ts
+++ b/src/runtime/panel/types/effect_types.ts
@@ -17,6 +17,9 @@ export enum EffectType {
   /** Clear overlay on the Content side */
   CLEAR_CONTENT = 'CLEAR_CONTENT',
 
+  /** item hover */
+  HOVER = 'HOVER',
+
   /** Run a capture with the given parameters (tabId/format/area/quality/scale) */
   CAPTURE = 'CAPTURE',
 

--- a/src/runtime/panel/types/ui_event_types.ts
+++ b/src/runtime/panel/types/ui_event_types.ts
@@ -52,6 +52,12 @@ export enum UIEventType {
 
   /** Emitted when an item's edit-selection checkbox changes state */
   ITEM_SELECTION_CHANGED = 'ITEM_SELECTION_CHANGED',
+
+  /** Start item hover */
+  ITEM_HOVER_IN = 'ITEM_HOVER_IN',
+
+  /** End item hover */
+  ITEM_HOVER_OUT = 'ITEM_HOVER_OUT',
 }
 
 /**
@@ -82,4 +88,6 @@ export type UIEventPayloadMap = {
     | { id: number; isCheck: boolean }
     | { group: string; isCheck: boolean }
     | { allCheck: boolean };
+  [UIEventType.ITEM_HOVER_IN]: { id: number };
+  [UIEventType.ITEM_HOVER_OUT]: undefined;
 };

--- a/src/styles/overlay.css
+++ b/src/styles/overlay.css
@@ -9,6 +9,11 @@
 .spsk-box {
   position: absolute;
   --spsk-border-w: 2px;
+  --spsk-accent: var(--spsk-border-color);
+  --spsk-hl-outline-w: 2px;
+  --spsk-hl-glow-w: 0px;
+  --spsk-hl-fill: color-mix(in srgb, var(--spsk-accent) 30%, transparent);
+  transition: box-shadow .12s ease, transform .12s ease, opacity .12s ease;
 }
 .spsk-box::before {
   content: '';
@@ -16,6 +21,29 @@
   inset: 0;
   border: var(--spsk-border-w) solid var(--spsk-border-color);
   z-index: 0;
+  pointer-events: none;
+}
+.spsk-box::after {
+  content: none;
+}
+
+.spsk-box.is-hovered {
+  z-index: 2;
+  box-shadow:
+    0 0 0 var(--spsk-hl-outline-w) var(--spsk-accent),
+    0 0 0 calc(var(--spsk-hl-outline-w) + var(--spsk-hl-glow-w))
+      color-mix(in srgb, var(--spsk-accent) 30%, transparent);
+}
+
+.spsk-box.is-hovered::before {
+  border-width: calc(var(--spsk-border-w) + 1px);
+}
+
+.spsk-box.is-hovered::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--spsk-hl-fill);
   pointer-events: none;
 }
 


### PR DESCRIPTION
Overview

* When the cursor hovers an item in the side panel list, temporarily highlight the corresponding element on the page (Content script) so users can quickly locate it and understand its spatial context.
* The highlight color matches the item’s badge color.
* Suppress hover behavior while performing drag & drop in the side panel.
* Add an ESLint rule regarding `console.log`.
