### PR TITLE
ensure single spsk-root and prevent duplicate listeners

### DIFF
--- a/src/styles/overlay.css
+++ b/src/styles/overlay.css
@@ -12,7 +12,7 @@
   --spsk-accent: var(--spsk-border-color);
   --spsk-hl-outline-w: 2px;
   --spsk-hl-glow-w: 0px;
-  --spsk-hl-fill: color-mix(in srgb, var(--spsk-accent) 30%, transparent);
+  --spsk-hl-fill: color-mix(in srgb, var(--spsk-accent) 10%, transparent);
   transition: box-shadow .12s ease, transform .12s ease, opacity .12s ease;
 }
 .spsk-box::before {


### PR DESCRIPTION
### Bug
Reloading/reattaching the panel caused multiple overlay host `<div id="spsk-root">` elements and duplicate scroll/resize listeners to be created.

### Fix
Reuse existing #spsk-root, ShadowRoot, and .spsk-overlay if present; inject the stylesheet only once; and guard scroll/resize listener registration so it occurs only once.