### PR TITLE
extract shared UI with @layer/@apply and simplify HTML

### DIFF
--- a/src/runtime/panel/pages/panel.html
+++ b/src/runtime/panel/pages/panel.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8" />
   <title data-i18n="app_name">Spec Sketch</title>
@@ -17,14 +18,11 @@
     }
   </style>
 </head>
-<body class="min-h-screen h-full bg-gradient-to-b antialiased
-            from-slate-50 to-slate-100 text-slate-800
-            dark:from-slate-900 dark:to-slate-950 dark:text-slate-100">
+
+<body class="app-body">
   <div class="p-4 mx-auto">
     <header class="mb-4">
-      <div class="flex items-center w-full rounded-xl backdrop-blur border py-2
-                  bg-white/70 border-slate-200/70
-                  dark:bg-slate-900/60 dark:border-slate-800">
+      <div class="panel-bar">
         <div class="flex items-center gap-2">
           <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-600 text-white shadow-sm">
             <img src="/assets/icons/icon128.png" class="h-7 w-7" alt="Spec Sketch logo" />
@@ -35,83 +33,33 @@
           <span id="status" data-i18n="status_restricted"></span>
         </div>
       </div>
-      <p data-i18n="panel_tagline" class="text-xs text-slate-500 dark:text-slate-400 mt-2"></p>
+      <p data-i18n="panel_tagline" class="tagline"></p>
     </header>
 
     <div class="flex gap-1 mb-6">
-      <button id="toggle-select"
-        class="inline-flex items-center gap-2 px-2.5 py-2 rounded-lg 
-              border border-slate-200 dark:border-slate-700 
-              bg-white dark:bg-slate-900 text-sm 
-              hover:bg-slate-50 dark:hover:bg-slate-800 
-              active:bg-slate-100 dark:active:bg-slate-800/80 
-              focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 
-              focus-visible:ring-offset-2 focus-visible:ring-offset-white 
-              dark:focus-visible:ring-offset-slate-900 
-              transition
-              disabled:bg-slate-100 dark:disabled:bg-slate-800/50 
-              disabled:text-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
-        aria-pressed="false">
+      <button id="toggle-select" class="btn" aria-pressed="false">
         <span class="inline-block w-3 h-3 rounded-full bg-slate-300" id="toggle-select-icon" data-role="icon"></span>
         <span id="toggle-select-label" data-i18n="toggle_off">Select mode: OFF</span>
       </button>
 
-      <button id="clear"
-        class="inline-flex items-center gap-2 px-2.5 py-2 rounded-lg 
-              border border-slate-200 dark:border-slate-700 
-              bg-white dark:bg-slate-900 text-sm 
-              hover:bg-slate-50 dark:hover:bg-slate-800 
-              active:bg-slate-100 dark:active:bg-slate-800/80 
-              focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 
-              focus-visible:ring-offset-2 focus-visible:ring-offset-white 
-              dark:focus-visible:ring-offset-slate-900 
-              transition
-              disabled:bg-slate-100 dark:disabled:bg-slate-800/50 
-              disabled:text-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
-        data-i18n="btn_clear"></button>
+      <button id="clear" class="btn" data-i18n="btn_clear"></button>
 
-      <span class="inline-flex rounded-lg shadow-sm">
-        <button id="capture"
-          class="inline-flex items-center gap-2 px-2.5 py-2 rounded-lg 
-                border border-slate-200 dark:border-slate-700 
-                bg-white dark:bg-slate-900 text-sm 
-                hover:bg-slate-50 dark:hover:bg-slate-800 
-                active:bg-slate-100 dark:active:bg-slate-800/80 
-                focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 
-                focus-visible:ring-offset-2 focus-visible:ring-offset-white 
-                dark:focus-visible:ring-offset-slate-900 
-                transition
-                disabled:bg-slate-100 dark:disabled:bg-slate-800/50 
-                disabled:text-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
-          data-i18n="btn_capture"></button>
-
-        <button id="capture-options-toggle" type="button"
-          class="inline-flex items-center justify-center px-2.5 py-2 w-9
-                border border-slate-200 dark:border-slate-700 border-l-0 -ml-px
-                rounded-r-lg rounded-l-none
-                bg-white dark:bg-slate-900 text-sm
-                hover:bg-slate-50 dark:hover:bg-slate-800
-                active:bg-slate-100 dark:active:bg-slate-800/80
-                focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
-                focus-visible:ring-offset-2 focus-visible:ring-offset-white
-                dark:focus-visible:ring-offset-slate-900 transition
-                disabled:bg-slate-100 dark:disabled:bg-slate-800/50
-                disabled:text-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
-          aria-controls="capture-options" aria-expanded="false" title="Options">▼</button>
+      <span class="btn-group">
+        <button id="capture" class="btn" data-i18n="btn_capture"></button>
+        <button id="capture-options-toggle" type="button" class="btn-split" aria-controls="capture-options"
+          aria-expanded="false" title="Options">▼</button>
       </span>
     </div>
 
-    <div id="capture-options"
-      class="hidden mb-6 rounded-xl border border-slate-200 dark:border-slate-800
-            bg-white dark:bg-slate-900 shadow-sm">
-      <div class="p-3 border-b border-slate-200/70 dark:border-slate-800/70">
-        <h2 class="text-sm font-medium text-slate-600 dark:text-slate-300" data-i18n="section_capture_options">Capture options</h2>
-        <span class="text-xs text-slate-400" data-i18n="hint_applies_on_capture">Applied when capturing</span>
+    <div id="capture-options" class="hidden mb-6 card">
+      <div class="card-head">
+        <h2 class="section-title" data-i18n="section_capture_options">Capture options</h2>
+        <span class="hint-xs" data-i18n="hint_applies_on_capture">Applied when capturing</span>
       </div>
 
       <div id="capture-options-form" class="p-3 space-y-3">
         <fieldset class="space-y-1">
-          <legend class="text-xs font-semibold text-slate-500 dark:text-slate-400" data-i18n="label_capture_format">Format</legend>
+          <legend class="label-xs" data-i18n="label_capture_format">Format</legend>
           <div class="flex items-center gap-3">
             <label class="inline-flex items-center gap-1 text-sm">
               <input type="radio" name="capture-format" value="png" class="accent-indigo-600" checked>
@@ -125,20 +73,16 @@
         </fieldset>
 
         <div class="jpeg-only">
-          <label for="jpeg-quality-range" class="block text-xs font-semibold text-slate-500 dark:text-slate-400"
-                data-i18n="label_jpeg_quality">JPEG quality (0–100)</label>
+          <label for="jpeg-quality-range" class="label-xs" data-i18n="label_jpeg_quality">JPEG quality (0–100)</label>
           <div class="flex items-center gap-2">
             <input id="jpeg-quality-range" name="quality" type="range" min="0" max="100" step="1" value="92"
-                  class="w-full accent-indigo-600">
-            <input id="jpeg-quality-number" type="number" min="0" max="100" step="1" value="92"
-                  class="w-16 rounded-md border border-slate-200 dark:border-slate-700 bg-transparent px-2 py-1 text-sm">
+              class="range">
+            <input id="jpeg-quality-number" type="number" min="0" max="100" step="1" value="92" class="input-sm">
           </div>
         </div>
 
         <fieldset class="space-y-1">
-          <legend class="text-xs font-semibold text-slate-500 dark:text-slate-400" data-i18n="label_capture_area">
-            Capture area
-          </legend>
+          <legend class="label-xs" data-i18n="label_capture_area">Capture area</legend>
           <div class="flex items-center gap-3">
             <label class="inline-flex items-center gap-1 text-sm">
               <input type="radio" name="capture-area" value="full" class="accent-indigo-600" checked>
@@ -152,141 +96,99 @@
         </fieldset>
 
         <div>
-          <label for="capture-scale-range" class="block text-xs font-semibold text-slate-500 dark:text-slate-400"
-                data-i18n="label_capture_scale">Scale (0.5–2.0)</label>
+          <label for="capture-scale-range" class="label-xs" data-i18n="label_capture_scale">Scale (0.5–2.0)</label>
           <div class="flex items-center gap-2">
             <input id="capture-scale-range" name="scale" type="range" min="0.5" max="2" step="0.1" value="1"
-                  class="w-full accent-indigo-600">
-            <input id="capture-scale-number" type="number" min="0.5" max="2" step="0.1" value="1"
-                  class="w-16 rounded-md border border-slate-200 dark:border-slate-700 bg-transparent px-2 py-1 text-sm">
+              class="range">
+            <input id="capture-scale-number" type="number" min="0.5" max="2" step="0.1" value="1" class="input-sm">
           </div>
           <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400" data-i18n="hint_capture_scale_note"></p>
         </div>
       </div>
     </div>
 
-    <div class="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm">
-      <div class="p-3 md:p-4 border-b border-slate-200/70 dark:border-slate-800/70">
+    <div class="card">
+      <div class="card-head-lg">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div>
-            <label for="badge-size-range"
-                  class="block text-xs font-semibold text-slate-500 dark:text-slate-400"
-                  data-i18n="label_badge_size">Badge size (10–30px)</label>
+            <label for="badge-size-range" class="label-xs" data-i18n="label_badge_size">Badge size (10–30px)</label>
             <div class="flex items-center gap-2">
               <input id="badge-size-range" name="badgeSize" type="range" min="10" max="30" step="2" value="14"
-                    class="w-full accent-indigo-600" />
-              <input id="badge-size-number" type="number" min="10" max="30" step="2" value="16"
-                    class="w-16 rounded-md border border-slate-200 dark:border-slate-700 bg-transparent px-2 py-1 text-sm" />
+                class="range" />
+              <input id="badge-size-number" type="number" min="10" max="30" step="2" value="16" class="input-sm" />
             </div>
           </div>
+
           <div>
             <div class="grid grid-cols-[1fr_1fr_auto] gap-4 items-end">
               <div>
-                <span class="block text-xs font-semibold text-slate-500 dark:text-slate-400"
-                      data-i18n="label_badge_color">Badge color</span>
-                <button id="badge-color-button" type="button"
-                  class="mt-1 inline-flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition
-                  border border-slate-200 bg-white hover:bg-slate-50
-                  dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800 focus:outline-none 
-                  focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white 
-                  dark:focus-visible:ring-offset-slate-900"
-                  popovertarget="badge-color-pop" popovertargetaction="toggle" aria-haspopup="listbox"
-                  style="anchor-name: --badge-color-trigger;">
+                <span class="label-xs" data-i18n="label_badge_color">Badge color</span>
+                <button id="badge-color-button" type="button" class="btn-field" popovertarget="badge-color-pop"
+                  popovertargetaction="toggle" aria-haspopup="listbox" style="anchor-name: --badge-color-trigger;">
                   <span class="flex items-center gap-2 min-w-0">
-                    <span id="badge-color-dot" class="inline-block w-4 h-4 rounded-full bg-slate-500 shrink-0"></span>
+                    <span id="badge-color-dot" class="color-dot bg-slate-500 shrink-0"></span>
                     <span id="badge-color-label" class="text-slate-600 dark:text-slate-300 truncate">Gray</span>
                   </span>
-                  <svg xmlns="http://www.w3.org/2000/svg"
-                      class="ml-auto h-4 w-4 opacity-60 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                    <path fill-rule="evenodd" 
+                  <svg xmlns="http://www.w3.org/2000/svg" class="ml-auto h-4 w-4 opacity-60 shrink-0"
+                    viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd"
                       d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
-                      clip-rule="evenodd"/>
+                      clip-rule="evenodd" />
                   </svg>
                 </button>
 
-                <div id="badge-color-pop" popover
-                    class="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-lg p-3 w-64">
+                <div id="badge-color-pop" popover class="popover">
                   <p class="mb-2 text-xs font-medium text-slate-500 dark:text-slate-400">Pick a color</p>
-
                   <div class="grid grid-cols-5 gap-2" role="listbox" aria-label="Badge color">
-                    <!-- Gray -->
                     <button type="button" role="radio" aria-selected="true" data-color-name="Gray"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent 
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-slate-500 group-aria-selected:ring-2 group-aria-selected:ring-indigo-400"></span>
+                      class="group color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span
+                        class="color-dot bg-slate-500 group-aria-selected:ring-2 group-aria-selected:ring-indigo-400"></span>
                       <span class="text-[10px] text-slate-500">Gray</span>
                     </button>
-                    <!-- Red -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Red"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent 
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-red-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-red-500"></span>
                       <span class="text-[10px] text-slate-500">Red</span>
                     </button>
-                    <!-- Orange -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Orange"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-orange-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-orange-500"></span>
                       <span class="text-[10px] text-slate-500">Orange</span>
                     </button>
-                    <!-- Green -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Green"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-green-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-green-500"></span>
                       <span class="text-[10px] text-slate-500">Green</span>
                     </button>
-                    <!-- Blue -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Blue"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-blue-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-blue-500"></span>
                       <span class="text-[10px] text-slate-500">Blue</span>
                     </button>
-                    <!-- Purple -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Purple"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-purple-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-purple-500"></span>
                       <span class="text-[10px] text-slate-500">Purple</span>
                     </button>
-                    <!-- Pink -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Pink"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-pink-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-pink-500"></span>
                       <span class="text-[10px] text-slate-500">Pink</span>
                     </button>
-                    <!-- Yellow -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Yellow"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-yellow-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-yellow-500"></span>
                       <span class="text-[10px] text-slate-500">Yellow</span>
                     </button>
-                    <!-- Lime -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Lime"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-lime-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-lime-500"></span>
                       <span class="text-[10px] text-slate-500">Lime</span>
                     </button>
-                    <!-- Cyan -->
                     <button type="button" role="radio" aria-selected="false" data-color-name="Cyan"
-                            class="group flex flex-col items-center gap-1 rounded-md border border-transparent
-                                   hover:border-slate-200 dark:hover:border-slate-700 p-2"
-                            popovertarget="badge-color-pop" popovertargetaction="hide">
-                      <span class="block w-6 h-6 rounded-full bg-cyan-500"></span>
+                      class="color-swatch-btn" popovertarget="badge-color-pop" popovertargetaction="hide">
+                      <span class="color-dot bg-cyan-500"></span>
                       <span class="text-[10px] text-slate-500">Cyan</span>
                     </button>
                   </div>
@@ -294,152 +196,112 @@
               </div>
 
               <div>
-                <label for="badge-shape-select"
-                      class="block text-xs font-semibold text-slate-500 dark:text-slate-400"
-                      data-i18n="badge_shape">Badge shape</label>
-                <select id="badge-shape-select" name="badgeShape"
-                        class="mt-1 block w-full rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm
-                               focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
-                               focus-visible:ring-offset-2 focus-visible:ring-offset-white
-                               dark:bg-slate-900 dark:border-slate-700 dark:focus-visible:ring-offset-slate-900">
+                <label for="badge-shape-select" class="label-xs" data-i18n="badge_shape">Badge shape</label>
+                <select id="badge-shape-select" name="badgeShape" class="select">
                   <option value="circle" selected data-i18n="badge_shape_circle">Circle</option>
                   <option value="square" data-i18n="badge_shape_square">Square</option>
                 </select>
               </div>
-              
+
               <div>
-                <label for="badge-shape-select"
-                      class="block text-xs font-semibold text-slate-500 dark:text-slate-400"
-                      data-i18n="common_delete">Badge Delete</label>
-                <button id="badge-delete-button" type="button"
-                        class="mt-1 inline-flex items-center justify-center h-9 w-13 px-2 rounded-lg
-                              border border-slate-200 bg-white hover:bg-slate-50
-                              dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800
-                              text-slate-600 hover:text-red-600
-                              focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400
-                              focus-visible:ring-offset-2 focus-visible:ring-offset-white
-                              dark:focus-visible:ring-offset-slate-900"
-                        aria-label="Delete">
+                <label for="badge-shape-select" class="label-xs" data-i18n="common_delete">Badge Delete</label>
+                <button id="badge-delete-button" type="button" class="btn-icon btn-icon--danger" aria-label="Delete">
                   <svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" clip-rule="evenodd"
-                          d="M7 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1h3a1 1 0 1 1 0 2h-1l-1 10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6H4a1 1 0 1 1 0-2h3V3Zm1 3a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V7a1 1 0 0 0-1-1Zm4 0a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V7a1 1 0 0 0-1-1Z"/>
+                      d="M7 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1h3a1 1 0 1 1 0 2h-1l-1 10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6H4a1 1 0 1 1 0-2h3V3Zm1 3a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V7a1 1 0 0 0-1-1Zm4 0a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V7a1 1 0 0 0-1-1Z" />
                   </svg>
                 </button>
               </div>
             </div>
           </div>
+
           <div>
             <div class="grid grid-cols-[1fr_1fr_auto] gap-4 items-end">
               <div>
-                <label for="badge-position-button"
-                      class="block text-xs font-semibold text-slate-500 dark:text-slate-400"
-                      data-i18n="badge_position">Badge Position</label>
-
-                <button id="badge-position-button" type="button"
-                        class="mt-1 inline-flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition
-                              border border-slate-200 bg-white hover:bg-slate-50
-                              dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800
-                              focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
-                              focus-visible:ring-offset-2 focus-visible:ring-offset-white
-                              dark:focus-visible:ring-offset-slate-900"
-                        popovertarget="badge-position-pop" popovertargetaction="toggle" aria-haspopup="listbox"
-                        style="anchor-name: --badge-position-trigger;">
+                <label for="badge-position-button" class="label-xs" data-i18n="badge_position">Badge Position</label>
+                <button id="badge-position-button" type="button" class="btn-field" popovertarget="badge-position-pop"
+                  popovertargetaction="toggle" aria-haspopup="listbox" style="anchor-name: --badge-position-trigger;">
                   <span class="flex items-center gap-2 min-w-0">
-                    <span id="badge-position-label" class="text-slate-600 dark:text-slate-300 truncate">Left Top Outside</span>
+                    <span id="badge-position-label" class="text-slate-600 dark:text-slate-300 truncate">Left Top
+                      Outside</span>
                   </span>
-                  <svg xmlns="http://www.w3.org/2000/svg"
-                      class="ml-auto h-4 w-4 opacity-60 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="ml-auto h-4 w-4 opacity-60 shrink-0"
+                    viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd"
-                          d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
-                          clip-rule="evenodd"/>
+                      d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
+                      clip-rule="evenodd" />
                   </svg>
                 </button>
 
-                <div id="badge-position-pop" popover
-                    class="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-lg p-3 w-64">
-                  <p class="mb-2 text-xs font-medium text-slate-500 dark:text-slate-400" data-i18n="pick_position">Pick a position</p>
+                <div id="badge-position-pop" popover class="popover">
+                  <p class="mb-2 text-xs font-medium text-slate-500 dark:text-slate-400" data-i18n="pick_position">Pick
+                    a position</p>
                   <div class="relative mx-auto aspect-square max-w-sm rounded-3xl text-white">
                     <button aria-label="Top Outside" data-position-name="top-outside"
                       class="pos-btn pos-btn--glyph absolute left-1/2 top-1 -translate-x-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Right Top Outside" data-position-name="right-top-outside"
                       class="pos-btn pos-btn--glyph absolute right-2 top-4 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Right Outside" data-position-name="right-outside"
                       class="pos-btn pos-btn--glyph absolute right-1 top-1/2 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Right Bottom Outside" data-position-name="right-bottom-outside"
                       class="pos-btn pos-btn--glyph absolute right-2 bottom-4 translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Bottom Outside" data-position-name="bottom-outside"
                       class="pos-btn pos-btn--glyph absolute bottom-1 left-1/2 -translate-x-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Left Bottom Outside" data-position-name="left-bottom-outside"
                       class="pos-btn pos-btn--glyph absolute bottom-4 left-2 translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Left Outside" data-position-name="left-outside"
                       class="pos-btn pos-btn--glyph absolute left-1 top-1/2 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Left Top Outside" data-position-name="left-top-outside"
                       class="pos-btn pos-btn--glyph absolute left-2 top-4 -translate-y-1/2" data-selected="true">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
 
-
                     <button aria-label="Top Inside" data-position-name="top-inside"
                       class="pos-btn pos-btn--glyph absolute left-1/2 top-9 -translate-x-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Right Top Inside" data-position-name="right-top-inside"
                       class="pos-btn pos-btn--glyph absolute right-8 top-12 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Right Inside" data-position-name="right-inside"
                       class="pos-btn pos-btn--glyph absolute right-8 top-1/2 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Right Bottom Inside" data-position-name="right-bottom-inside"
                       class="pos-btn pos-btn--glyph absolute right-8 bottom-12 translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Bottom Inside" data-position-name="bottom-inside"
                       class="pos-btn pos-btn--glyph absolute bottom-9 left-1/2 -translate-x-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Left Bottom Inside" data-position-name="left-bottom-inside"
                       class="pos-btn pos-btn--glyph absolute bottom-12 left-8 translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Left Inside" data-position-name="left-inside"
                       class="pos-btn pos-btn--glyph absolute left-8 top-1/2 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Left Top Inside" data-position-name="left-top-inside"
                       class="pos-btn pos-btn--glyph absolute left-8 top-12 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
                     </button>
-
                     <button aria-label="Center" data-position-name="center"
                       class="pos-btn pos-btn--glyph absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
                       <span aria-hidden="true" class="dot"></span>
@@ -451,17 +313,15 @@
           </div>
         </div>
       </div>
+
       <div class="flex items-center justify-between p-3 border-b border-slate-200/70 dark:border-slate-800/70">
         <div class="flex items-center gap-2 min-w-0 flex-1">
           <div class="shrink-0 self-stretch flex items-center">
-            <input type="checkbox" name="item-select" value="all"
-                  class="h-4 w-4 border border-slate-300 dark:border-slate-700 outline-none 
-                         focus:ring-2 focus:ring-indigo-500 accent-indigo-600">
+            <input type="checkbox" name="item-select" value="all" class="checkbox">
           </div>
-          <h2 class="text-sm font-medium text-slate-600 dark:text-slate-300" data-i18n="section_selected_items">Selected items</h2>
+          <h2 class="section-title" data-i18n="section_selected_items">Selected items</h2>
         </div>
-        <span id="select-count" 
-              class="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">0</span>
+        <span id="select-count" class="count-pill">0</span>
       </div>
 
       <div id="select-empty" class="p-6 text-center text-sm text-slate-500 dark:text-slate-400">
@@ -474,4 +334,5 @@
 
   <script type="module" src="index.js"></script>
 </body>
+
 </html>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -3,20 +3,136 @@
 @tailwind utilities;
 
 @layer components {
+  .app-body {
+    @apply min-h-screen h-full bg-gradient-to-b antialiased
+           from-slate-50 to-slate-100 text-slate-800
+           dark:from-slate-900 dark:to-slate-950 dark:text-slate-100;
+  }
+  .panel-bar {
+    @apply flex items-center w-full rounded-xl backdrop-blur border py-2
+           bg-white/70 border-slate-200/70
+           dark:bg-slate-900/60 dark:border-slate-800;
+  }
+  .tagline {
+    @apply text-xs text-slate-500 dark:text-slate-400 mt-2;
+  }
+
+  .card {
+    @apply rounded-xl border border-slate-200 dark:border-slate-800
+           bg-white dark:bg-slate-900 shadow-sm;
+  }
+  .card-head {
+    @apply p-3 border-b border-slate-200/70 dark:border-slate-800/70;
+  }
+  .card-head-lg {
+    @apply p-3 md:p-4 border-b border-slate-200/70 dark:border-slate-800/70;
+  }
+
+  .section-title {
+    @apply text-sm font-medium text-slate-600 dark:text-slate-300;
+  }
+  .hint-xs {
+    @apply text-xs text-slate-400;
+  }
+  .label-xs {
+    @apply block text-xs font-semibold text-slate-500 dark:text-slate-400;
+  }
+
+  .btn {
+    @apply inline-flex items-center gap-2 px-2.5 py-2 rounded-lg
+           border border-slate-200 dark:border-slate-700
+           bg-white dark:bg-slate-900 text-sm
+           hover:bg-slate-50 dark:hover:bg-slate-800
+           active:bg-slate-100 dark:active:bg-slate-800/80
+           focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
+           focus-visible:ring-offset-2 focus-visible:ring-offset-white
+           dark:focus-visible:ring-offset-slate-900
+           transition
+           disabled:bg-slate-100 dark:disabled:bg-slate-800/50
+           disabled:text-slate-400 disabled:cursor-not-allowed disabled:opacity-60;
+  }
+  .btn-group {
+    @apply inline-flex rounded-lg shadow-sm overflow-hidden;
+  }
+  .btn-split {
+    @apply inline-flex items-center justify-center px-2.5 py-2 w-9
+           border border-slate-200 dark:border-slate-700 border-l-0 -ml-px
+           rounded-r-lg rounded-l-none
+           bg-white dark:bg-slate-900 text-sm
+           hover:bg-slate-50 dark:hover:bg-slate-800
+           active:bg-slate-100 dark:active:bg-slate-800/80
+           focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
+           focus-visible:ring-offset-2 focus-visible:ring-offset-white
+           dark:focus-visible:ring-offset-slate-900 transition
+           disabled:bg-slate-100 dark:disabled:bg-slate-800/50
+           disabled:text-slate-400 disabled:cursor-not-allowed disabled:opacity-60;
+  }
+  .btn-field {
+    @apply mt-1 inline-flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition
+           border border-slate-200 bg-white hover:bg-slate-50
+           dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800
+           focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
+           focus-visible:ring-offset-2 focus-visible:ring-offset-white
+           dark:focus-visible:ring-offset-slate-900;
+  }
+  .btn-icon {
+    @apply mt-1 inline-flex items-center justify-center h-9 px-2 rounded-lg
+           border border-slate-200 bg-white hover:bg-slate-50
+           dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800
+           text-slate-600 focus:outline-none;
+  }
+  .btn-icon--danger {
+    @apply hover:text-red-600
+           focus-visible:ring-2 focus-visible:ring-red-400
+           focus-visible:ring-offset-2 focus-visible:ring-offset-white
+           dark:focus-visible:ring-offset-slate-900;
+  }
+
+  .range {
+    @apply w-full accent-indigo-600;
+  }
+  .input-sm {
+    @apply w-16 rounded-md border border-slate-200 dark:border-slate-700
+           bg-transparent px-2 py-1 text-sm;
+  }
+  .select {
+    @apply mt-1 block w-full rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm
+           focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
+           focus-visible:ring-offset-2 focus-visible:ring-offset-white
+           dark:bg-slate-900 dark:border-slate-700 dark:focus-visible:ring-offset-slate-900;
+  }
+  .checkbox {
+    @apply h-4 w-4 border border-slate-300 dark:border-slate-700 outline-none
+           focus:ring-2 focus:ring-indigo-500 accent-indigo-600;
+  }
+  .count-pill {
+    @apply text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-600
+           dark:bg-slate-800 dark:text-slate-300;
+  }
+
+  .popover {
+    @apply rounded-xl border border-slate-200 dark:border-slate-800
+           bg-white dark:bg-slate-900 shadow-lg p-3 w-64;
+  }
+  .color-swatch-btn {
+    @apply flex flex-col items-center gap-1 rounded-md border border-transparent
+           hover:border-slate-200 dark:hover:border-slate-700 p-2;
+  }
+  .color-dot {
+    @apply block w-4 h-4 rounded-full;
+  }
+
   .pos-btn {
     @apply transition duration-150 bg-white text-slate-900 focus-visible:outline-none
       focus-visible:ring-2 focus-visible:ring-indigo-400 data-[selected=true]:bg-indigo-600
       data-[selected=true]:text-white data-[selected=true]:shadow-lg;
   }
-
   .pos-btn--glyph {
     @apply w-6 h-6 rounded-full flex items-center justify-center hover:bg-indigo-300;
   }
-
   .dot {
     @apply block rounded-full w-1.5 h-1.5 bg-indigo-400;
   }
-
   .pos-btn {
     @apply border border-indigo-400;
   }


### PR DESCRIPTION
Use Tailwind `@layer` and `@apply` to reduce repeated utilities and improve readability/consistency in the panel HTML. No functional changes.