### PR TITLE
Fix full-page capture on inner scroll containers

### DIFF
--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -1,4 +1,4 @@
-import type { Anchor, ScreenItem } from './types';
+import type { Anchor, ContentSize, ScreenItem } from './types';
 
 const P2C = {
   PING: 'PING',
@@ -6,11 +6,13 @@ const P2C = {
   RENDER: 'RENDER',
   CLEAR: 'CLEAR',
   HOVER: 'HOVER',
+  MEASURE_SIZE: 'MEASURE_SIZE',
 } as const;
 
 const C2P = {
   SELECTED: 'SELECTED',
   MISSING_IDS: 'MISSING_IDS',
+  CONTENT_SIZE_RESULT: 'CONTENT_SIZE_RESULT',
 } as const;
 
 const B2P = {
@@ -29,11 +31,13 @@ export type PanelToContent =
   | { type: typeof P2C.TOGGLE_SELECT; payload: { enabled: boolean } }
   | { type: typeof P2C.RENDER; payload: { items: ScreenItem[] } }
   | { type: typeof P2C.CLEAR }
-  | { type: typeof P2C.HOVER; payload: { id: number | null } };
+  | { type: typeof P2C.HOVER; payload: { id: number | null } }
+  | { type: typeof P2C.MEASURE_SIZE };
 
 export type ContentToPanel =
   | { type: typeof C2P.SELECTED; payload: { anchors: Anchor[] } }
-  | { type: typeof C2P.MISSING_IDS; payload: { missingIds: number[] } };
+  | { type: typeof C2P.MISSING_IDS; payload: { missingIds: number[] } }
+  | { type: typeof C2P.CONTENT_SIZE_RESULT; payload: ContentSize };
 
 export type BackgroundToPanel = {
   type: typeof B2P.ACTIVE_TAB_CHANGED;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -110,3 +110,8 @@ export type ScreenState = {
   defaultPosition: ItemPosition;
   defaultGroup: ItemGroup;
 };
+
+export type ContentSize = {
+  width: number;
+  height: number;
+};

--- a/src/infra/cdp/cdp_client.ts
+++ b/src/infra/cdp/cdp_client.ts
@@ -5,31 +5,21 @@ export type Debuggee = chrome.debugger.Debuggee;
 /**
  * Wraps `chrome.runtime.lastError` into a standard `Error` instance.
  *
- * @returns An `Error` when a lastError exists; otherwise `null`.
+ * @returns An `Error` if a last error exists; otherwise `null`.
  */
 function lastError(): Error | null {
   const err = chrome.runtime.lastError;
   return err ? new Error(err.message || String(err)) : null;
 }
 
-/**
- * Attaches the Chrome Debugger (CDP) to the given target.
- *
- * @param target - The debuggee (e.g., `{ tabId }`) to attach to.
- * @returns A promise that resolves when the debugger is attached, or rejects on error.
- */
-export async function attach(target: Debuggee): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    chrome.debugger.attach(target, CDP_VERSION, () => {
-      const err = lastError();
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
-  });
-}
+/** Tracks tabIds that this extension currently owns (attached by itself). */
+const OWNED = new Set<number>();
+
+/** Clears ownership on detach (covers external causes like opening/closing DevTools). */
+chrome.debugger.onDetach.addListener((debuggee) => {
+  const id = debuggee.tabId;
+  if (typeof id === 'number') OWNED.delete(id);
+});
 
 /**
  * Detaches the Chrome Debugger (CDP) from the given target.
@@ -37,10 +27,60 @@ export async function attach(target: Debuggee): Promise<void> {
  * @param target - The debuggee to detach from.
  * @returns A promise that resolves once detachment completes.
  */
-export async function detach(target: Debuggee): Promise<void> {
+async function detach(target: Debuggee): Promise<void> {
   await new Promise<void>((resolve) => {
     chrome.debugger.detach(target, () => resolve());
   });
+}
+
+/**
+ * Safely attaches to the target. If a previous session owned by this extension
+ * is already attached, it reuses it instead of failing.
+ *
+ * @param target - The debuggee to attach to (e.g., `{ tabId }`).
+ * @returns A promise that resolves to `true` when this call performed a new attach,
+ *          or `false` when an existing owned session is reused.
+ * @throws If another client (DevTools/another extension) is attached, or on other attach errors.
+ */
+export async function attachOwned(target: Debuggee): Promise<boolean> {
+  const tabId = target.tabId ?? null;
+  return await new Promise<boolean>((resolve, reject) => {
+    chrome.debugger.attach(target, CDP_VERSION, () => {
+      const err = chrome.runtime.lastError;
+      if (!err) {
+        if (tabId != null) OWNED.add(tabId);
+        resolve(true); // newly attached by this call
+        return;
+      }
+      const msg = err.message || '';
+      if (msg.includes('Another debugger is already attached')) {
+        // Already attached: reuse only if owned by this extension.
+        if (tabId != null && OWNED.has(tabId)) {
+          resolve(false); // reuse existing owned session
+        } else {
+          reject(new Error('Debugger is already attached by another client (DevTools/extension).'));
+        }
+      } else {
+        reject(new Error(msg));
+      }
+    });
+  });
+}
+
+/**
+ * Safely detaches only when the current extension owns the session.
+ * No-ops if the target is not owned.
+ *
+ * @param target - The debuggee to detach from.
+ * @returns A promise that resolves after detaching (or immediately if not owned).
+ */
+export async function detachOwned(target: Debuggee): Promise<void> {
+  const tabId = target.tabId ?? null;
+  if (tabId == null) return;
+  if (!OWNED.has(tabId)) return; // not owned by this extension
+
+  await detach(target);
+  OWNED.delete(tabId);
 }
 
 /**

--- a/src/runtime/content/main.ts
+++ b/src/runtime/content/main.ts
@@ -3,6 +3,7 @@ import { MSG_TYPE, type PanelToContent } from '@common/messages';
 import type { ScreenItem } from '@common/types';
 
 import { buildCssAnchor } from './anchor';
+import { measureContentSize } from './measure';
 import {
   clearOverlay,
   getMissingIds,
@@ -45,6 +46,10 @@ chrome.runtime.onConnect.addListener(async (p) => {
       case MSG_TYPE.HOVER:
         await highlightOverlay(msg.payload.id);
         break;
+      case MSG_TYPE.MEASURE_SIZE: {
+        const payload = measureContentSize();
+        p.postMessage({ type: MSG_TYPE.CONTENT_SIZE_RESULT, payload });
+      }
     }
   });
 

--- a/src/runtime/content/measure.ts
+++ b/src/runtime/content/measure.ts
@@ -1,0 +1,122 @@
+import { ContentSize } from '@common/types';
+
+/**
+ * @summary Type guard to ensure the provided element is an HTMLElement.
+ * @param el The element to check.
+ * @returns True if the element is an HTMLElement; otherwise, false.
+ */
+function isHTMLElement(el: Element): el is HTMLElement {
+  return el instanceof HTMLElement;
+}
+
+/**
+ * @summary Gets the horizontal page offset in CSS pixels, preferring visualViewport when available.
+ * @returns The horizontal page offset (CSS pixels).
+ */
+function pageOffsetX(): number {
+  // Prefer visualViewport for pinch-zoom scenarios; often equals window.scrollX on desktop.
+  return (window.visualViewport?.pageLeft ?? window.scrollX) || 0;
+}
+
+/**
+ * @summary Gets the vertical page offset in CSS pixels, preferring visualViewport when available.
+ * @returns The vertical page offset (CSS pixels).
+ */
+function pageOffsetY(): number {
+  // Prefer visualViewport for pinch-zoom scenarios; often equals window.scrollY on desktop.
+  return (window.visualViewport?.pageTop ?? window.scrollY) || 0;
+}
+
+/**
+ * @summary Measures the maximum rendered content area of the page in CSS pixels, considering
+ * scroll containers (e.g., overflowed <main>), fixed/absolute/transform layouts, and negative overflow.
+ * Also returns rough selectors for the elements contributing to width/height.
+ * @returns A ContentSize object containing width, height, and selector hints (widestBy, tallestBy).
+ */
+export function measureContentSize(): ContentSize {
+  const docEl = document.documentElement;
+  const body = document.body ?? null;
+  const se = (document.scrollingElement as HTMLElement | null) ?? null;
+
+  // Baseline sizes from document/body/scrollingElement (size metrics only).
+  const baseW = Math.max(
+    docEl.scrollWidth,
+    docEl.offsetWidth,
+    docEl.clientWidth,
+    body?.scrollWidth ?? 0,
+    body?.offsetWidth ?? 0,
+    body?.clientWidth ?? 0,
+    se?.scrollWidth ?? 0,
+    se?.offsetWidth ?? 0,
+    se?.clientWidth ?? 0,
+  );
+  const baseH = Math.max(
+    docEl.scrollHeight,
+    docEl.offsetHeight,
+    docEl.clientHeight,
+    body?.scrollHeight ?? 0,
+    body?.offsetHeight ?? 0,
+    body?.clientHeight ?? 0,
+    se?.scrollHeight ?? 0,
+    se?.offsetHeight ?? 0,
+    se?.clientHeight ?? 0,
+  );
+
+  // Aggregate element positions (visual bounding box) and sizes (scroll totals) separately.
+  let minLeft = Number.POSITIVE_INFINITY;
+  let minTop = Number.POSITIVE_INFINITY;
+  let maxRight = Number.NEGATIVE_INFINITY;
+  let maxBottom = Number.NEGATIVE_INFINITY;
+
+  let maxScrollW = 0;
+  let maxScrollH = 0;
+
+  const offX = pageOffsetX();
+  const offY = pageOffsetY();
+
+  const elements = Array.from(document.querySelectorAll('*')).filter(isHTMLElement);
+  for (const el of elements) {
+    // Size metrics (total scrollable size of containers).
+    if (el.scrollWidth > maxScrollW) {
+      maxScrollW = el.scrollWidth;
+    }
+    if (el.scrollHeight > maxScrollH) {
+      maxScrollH = el.scrollHeight;
+    }
+
+    // Position metrics (visual bounds) normalized to page coordinates.
+    const r = el.getBoundingClientRect();
+    const left = r.left + offX;
+    const right = r.right + offX;
+    const top = r.top + offY;
+    const bottom = r.bottom + offY;
+
+    if (left < minLeft) minLeft = left;
+    if (top < minTop) minTop = top;
+    if (right > maxRight) {
+      maxRight = right;
+    }
+    if (bottom > maxBottom) {
+      maxBottom = bottom;
+    }
+  }
+
+  // Guards for pages with no elements.
+  if (!isFinite(minLeft)) minLeft = 0;
+  if (!isFinite(minTop)) minTop = 0;
+  if (!isFinite(maxRight)) maxRight = baseW;
+  if (!isFinite(maxBottom)) maxBottom = baseH;
+
+  // Visual bounding-box size (position-based).
+  const bboxWidth = Math.max(0, Math.ceil(maxRight - minLeft));
+  const bboxHeight = Math.max(0, Math.ceil(maxBottom - minTop));
+
+  // Final size: the maximum of document baseline, scroll totals, and visual bounds.
+  const width = Math.max(baseW, maxScrollW, bboxWidth);
+  const height = Math.max(baseH, maxScrollH, bboxHeight);
+
+  return {
+    width,
+    height,
+  };
+}

--- a/src/runtime/panel/app/update.ts
+++ b/src/runtime/panel/app/update.ts
@@ -157,9 +157,16 @@ export function update(model: Model, action: Action): { model: Model; effects: E
         effects: [],
       };
 
-    case ActionType.CAPTURE_REQUESTED:
-      if (model.tabId == null)
+    case ActionType.MEASURE_CONTENT_SIZE:
+      return {
+        model,
+        effects: [{ kind: EffectType.MEASURE_CONTENT_SIZE }],
+      };
+
+    case ActionType.CAPTURE_REQUESTED: {
+      if (model.tabId == null) {
         return { model, effects: [{ kind: EffectType.NOTIFY_ERROR, error: 'No tabId' }] };
+      }
       return {
         model,
         effects: [
@@ -171,10 +178,12 @@ export function update(model: Model, action: Action): { model: Model; effects: E
               area: model.capture.area,
               quality: model.capture.quality,
               scale: model.capture.scale,
+              contentSize: action.contentSize,
             },
           },
         ],
       };
+    }
 
     case ActionType.CAPTURE_SUCCEEDED:
       return { model, effects: [] };

--- a/src/runtime/panel/controller/panel_controller.ts
+++ b/src/runtime/panel/controller/panel_controller.ts
@@ -61,7 +61,9 @@ export class PanelController {
       this.dispatch({ type: ActionType.TOGGLE_SELECT }),
     );
     this.view.on(UIEventType.CLEAR, () => this.dispatch({ type: ActionType.CLEAR_ALL }));
-    this.view.on(UIEventType.CAPTURE, () => this.dispatch({ type: ActionType.CAPTURE_REQUESTED }));
+    this.view.on(UIEventType.CAPTURE, () =>
+      this.dispatch({ type: ActionType.MEASURE_CONTENT_SIZE }),
+    );
 
     this.view.on(UIEventType.BADGE_SIZE_CHANGE, ({ size }) =>
       this.dispatch({ type: ActionType.SET_BADGE_SIZE, size }),
@@ -173,6 +175,9 @@ export class PanelController {
           });
           break;
         }
+        case EffectType.MEASURE_CONTENT_SIZE:
+          await this.conn?.api.measureSize();
+          break;
         case EffectType.CAPTURE:
           try {
             await capture(fx.payload);
@@ -236,6 +241,11 @@ export class PanelController {
         this.dispatch({
           type: ActionType.SET_MISSING_IDS,
           missingIds: msg.payload.missingIds,
+        });
+      } else if (msg?.type === MSG_TYPE.CONTENT_SIZE_RESULT) {
+        this.dispatch({
+          type: ActionType.CAPTURE_REQUESTED,
+          contentSize: msg.payload,
         });
       }
     });

--- a/src/runtime/panel/messaging/api.ts
+++ b/src/runtime/panel/messaging/api.ts
@@ -59,6 +59,13 @@ export class PanelApi {
   }
 
   /**
+   * Sends a request to measure the current content size.
+   */
+  measureSize() {
+    return this.send({ type: MSG_TYPE.MEASURE_SIZE });
+  }
+
+  /**
    * Performs a connectivity health check (round-trip).
    * Sent as a request expecting a reply.
    *

--- a/src/runtime/panel/types/action_types.ts
+++ b/src/runtime/panel/types/action_types.ts
@@ -1,5 +1,6 @@
 import type {
   Anchor,
+  ContentSize,
   ItemColor,
   ItemGroup,
   ItemPosition,
@@ -76,6 +77,9 @@ export enum ActionType {
   /** Toggle capture options dropdown (expand/collapse) */
   TOGGLE_CAPTURE_PANEL = 'TOGGLE_CAPTURE_PANEL',
 
+  /** request measuring the content size */
+  MEASURE_CONTENT_SIZE = 'MEASURE_CONTENT_SIZE',
+
   /** Request to run a capture */
   CAPTURE_REQUESTED = 'CAPTURE_REQUESTED',
 
@@ -139,7 +143,8 @@ export type Action =
   | { type: ActionType.SET_CAPTURE_SCALE; scale: number }
   | { type: ActionType.BADGE_DELETE }
   | { type: ActionType.TOGGLE_CAPTURE_PANEL }
-  | { type: ActionType.CAPTURE_REQUESTED }
+  | { type: ActionType.MEASURE_CONTENT_SIZE }
+  | { type: ActionType.CAPTURE_REQUESTED; contentSize: ContentSize }
   | { type: ActionType.CAPTURE_SUCCEEDED }
   | { type: ActionType.CAPTURE_FAILED; error: unknown }
   | { type: ActionType.REORDER_ITEMS; fromId: number; fromIndex: number; toIndex: number }

--- a/src/runtime/panel/types/effect_types.ts
+++ b/src/runtime/panel/types/effect_types.ts
@@ -1,4 +1,4 @@
-import { ScreenItem } from '@common/types';
+import { ContentSize, ScreenItem } from '@common/types';
 
 /**
  * EffectType
@@ -22,6 +22,9 @@ export enum EffectType {
   /** item hover */
   HOVER = 'HOVER',
 
+  /** request measuring the content size */
+  MEASURE_CONTENT_SIZE = 'MEASURE_CONTENT_SIZE',
+
   /** Run a capture with the given parameters (tabId/format/area/quality/scale) */
   CAPTURE = 'CAPTURE',
 
@@ -43,6 +46,7 @@ export type Effect =
   | { kind: EffectType.TOGGLE_SELECT_ON_CONTENT; enabled: boolean }
   | { kind: EffectType.CLEAR_CONTENT }
   | { kind: EffectType.HOVER; id: number | null }
+  | { kind: EffectType.MEASURE_CONTENT_SIZE }
   | {
       kind: EffectType.CAPTURE;
       payload: {
@@ -51,6 +55,7 @@ export type Effect =
         area: 'full' | 'viewport';
         quality: number;
         scale: number;
+        contentSize: ContentSize;
       };
     }
   | { kind: EffectType.CLEAR_STATE }

--- a/tests/unit-chrome/infra/cdp_client.test.ts
+++ b/tests/unit-chrome/infra/cdp_client.test.ts
@@ -1,45 +1,99 @@
-import { attach, CDP_VERSION, type Debuggee, detach, send } from '@infra/cdp/cdp_client';
+import { attachOwned, type Debuggee, detachOwned, send } from '@infra/cdp/cdp_client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { simulateLastError } from '../../setup/chrome.setup';
+import { DETACH_REASON, emitDebuggerOnDetach, simulateLastError } from '../../setup/chrome.setup';
 
 describe('infra/cdp/cdp_client', () => {
   const c = (globalThis as typeof globalThis & { chrome: typeof chrome }).chrome;
+  const attach = vi.mocked(c.debugger.attach);
+  const detach = vi.mocked(c.debugger.detach);
   const sendCommand = vi.mocked(c.debugger.sendCommand);
 
   const target: Debuggee = { tabId: 1 } as unknown as Debuggee;
+  const fresh = (id: number): Debuggee => ({ tabId: id }) as unknown as Debuggee;
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('attach', () => {
-    it('attach: resolves when no lastError', async () => {
-      await attach(target);
-
-      // Assert
+  describe('attachOwned', () => {
+    it('resolves true when newly attached (and records ownership)', async () => {
+      attach.mockImplementationOnce(((_t, _v, cb) => cb?.()) as typeof chrome.debugger.attach);
+      const ok = await attachOwned(target);
+      expect(ok).toBe(true);
       expect(c.debugger.attach).toHaveBeenCalledTimes(1);
-      expect(c.debugger.attach).toHaveBeenCalledWith(target, CDP_VERSION, expect.any(Function));
+      expect(c.debugger.attach).toHaveBeenCalledWith(
+        target,
+        expect.any(String),
+        expect.any(Function),
+      );
     }, 1000);
 
-    it('attach: rejects with lastError message', async () => {
-      // Arrange & Act & Assert
-      await expect(simulateLastError('attach failed', () => attach(target))).rejects.toThrow(
-        'attach failed',
-      );
+    it('resolves false when already attached but owned by this extension (reuse)', async () => {
+      attach.mockImplementationOnce(((_t, _v, cb) => cb?.()) as typeof chrome.debugger.attach);
+      await attachOwned(target);
 
+      // "Another debugger..." error → false if already owned
+      attach.mockImplementationOnce(((_t, _v, cb) => {
+        return simulateLastError('Another debugger is already attached', () => cb?.());
+      }) as typeof chrome.debugger.attach);
+
+      const reused = await attachOwned(target);
+      expect(reused).toBe(false);
+      expect(c.debugger.attach).toHaveBeenCalledTimes(2);
+    }, 1000);
+
+    it('rejects when already attached by another client (not owned)', async () => {
+      const t2 = fresh(99);
+      attach.mockImplementationOnce(((_t, _v, cb) => {
+        return simulateLastError('Another debugger is already attached', () => cb?.());
+      }) as typeof chrome.debugger.attach);
+
+      await expect(attachOwned(t2)).rejects.toThrow(
+        'Debugger is already attached by another client (DevTools/extension).',
+      );
+      expect(c.debugger.attach).toHaveBeenCalledTimes(1);
+    }, 1000);
+
+    it('rejects with other attach errors (propagates message)', async () => {
+      const t3 = fresh(100);
+      attach.mockImplementationOnce(((_t, _v, cb) => {
+        return simulateLastError('Some other attach error', () => cb?.());
+      }) as typeof chrome.debugger.attach);
+
+      await expect(attachOwned(t3)).rejects.toThrow('Some other attach error');
       expect(c.debugger.attach).toHaveBeenCalledTimes(1);
     }, 1000);
   });
 
-  describe('detach', () => {
-    it('detach: resolves', async () => {
-      // Act
-      await detach(target);
+  describe('detachOwned', () => {
+    it('no-ops when target is not owned (does not call chrome.debugger.detach)', async () => {
+      const t2 = fresh(200); // Unowned ID
+      await detachOwned(t2);
+      expect(detach).not.toHaveBeenCalled();
+    }, 1000);
 
-      // Assert
-      expect(c.debugger.detach).toHaveBeenCalledTimes(1);
-      expect(c.debugger.detach).toHaveBeenCalledWith(target, expect.any(Function));
+    it('detaches when owned, then clears ownership (2nd call is no-op)', async () => {
+      attach.mockImplementationOnce(((_t, _v, cb) => cb?.()) as typeof chrome.debugger.attach);
+      await attachOwned(target);
+
+      await detachOwned(target);
+      await detachOwned(target);
+
+      expect(detach).toHaveBeenCalledTimes(1);
+      expect(detach).toHaveBeenCalledWith(target, expect.any(Function));
+    }, 1000);
+
+    it('onDetach listener clears ownership; then detachOwned is a no-op', async () => {
+      attach.mockImplementationOnce(((_t, _v, cb) => cb?.()) as typeof chrome.debugger.attach);
+      await attachOwned(target);
+      emitDebuggerOnDetach(
+        { tabId: target.tabId } as chrome.debugger.Debuggee,
+        DETACH_REASON.TARGET_CLOSED,
+      );
+
+      await detachOwned(target);
+      expect(detach).not.toHaveBeenCalled();
     }, 1000);
   });
 

--- a/tests/unit-dom/content/measure.test.ts
+++ b/tests/unit-dom/content/measure.test.ts
@@ -1,0 +1,237 @@
+import { measureContentSize } from '@content/measure';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Rect = { left: number; top: number; right: number; bottom: number };
+
+function setDocMetrics(opts: {
+  doc?: Partial<
+    Record<
+      | 'scrollWidth'
+      | 'scrollHeight'
+      | 'offsetWidth'
+      | 'offsetHeight'
+      | 'clientWidth'
+      | 'clientHeight',
+      number
+    >
+  >;
+  body?: Partial<
+    Record<
+      | 'scrollWidth'
+      | 'scrollHeight'
+      | 'offsetWidth'
+      | 'offsetHeight'
+      | 'clientWidth'
+      | 'clientHeight',
+      number
+    >
+  >;
+  se?: Partial<
+    Record<
+      | 'scrollWidth'
+      | 'scrollHeight'
+      | 'offsetWidth'
+      | 'offsetHeight'
+      | 'clientWidth'
+      | 'clientHeight',
+      number
+    >
+  >;
+}) {
+  const se = (document.scrollingElement as HTMLElement | null) ?? document.documentElement;
+
+  const apply = (el: Element, map?: Record<string, number>) => {
+    if (!map) return;
+    Object.entries(map).forEach(([k, v]) => {
+      Object.defineProperty(el, k, { configurable: true, value: v });
+    });
+  };
+
+  apply(document.documentElement, opts.doc as Record<string, number> | undefined);
+  apply(document.body!, opts.body as Record<string, number> | undefined);
+  if (se !== document.documentElement) {
+    apply(se, opts.se as Record<string, number> | undefined);
+  }
+}
+
+function makeEl(rect: Rect, scroll: { w?: number; h?: number } = {}): HTMLElement {
+  const el = document.createElement('div');
+  if (!document.body) document.appendChild(document.createElement('body'));
+  document.body!.appendChild(el);
+
+  // instance-level override of getBoundingClientRect for this element
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    configurable: true,
+    value(): DOMRect {
+      return {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.right - rect.left,
+        height: rect.bottom - rect.top,
+        x: rect.left,
+        y: rect.top,
+        toJSON() {},
+      } as unknown as DOMRect;
+    },
+  });
+
+  // scroll metrics
+  Object.defineProperty(el, 'scrollWidth', { configurable: true, value: scroll.w ?? 0 });
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: scroll.h ?? 0 });
+
+  return el;
+}
+
+function mockVisualViewport(pageLeft: number | undefined, pageTop: number | undefined) {
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: pageLeft == null && pageTop == null ? undefined : { pageLeft, pageTop },
+  });
+}
+
+function mockScrollOffsets(scrollX: number, scrollY: number) {
+  // jsdom's scrollX/scrollY are almost read-only, so replace them with defineProperty
+  Object.defineProperty(window, 'scrollX', { configurable: true, value: scrollX });
+  Object.defineProperty(window, 'scrollY', { configurable: true, value: scrollY });
+  Object.defineProperty(window, 'pageXOffset', { configurable: true, value: scrollX });
+  Object.defineProperty(window, 'pageYOffset', { configurable: true, value: scrollY });
+}
+
+describe('content/measure', () => {
+  beforeEach(() => {
+    // reset DOM
+    document.body?.remove();
+    document.documentElement.innerHTML = '<head></head><body></body>';
+
+    // clear offsets/visualViewport
+    mockVisualViewport(undefined, undefined);
+    mockScrollOffsets(0, 0);
+
+    // clear any spy/mocks
+    vi.restoreAllMocks();
+  });
+
+  describe('measureContentSize', () => {
+    it('returns baseline size when no elements exist (guards normalize infinities)', () => {
+      // Arrange: mock querySelectorAll to empty and set baseline metrics
+      const spy = vi
+        .spyOn(document, 'querySelectorAll')
+        .mockReturnValue([] as unknown as NodeListOf<Element>);
+      setDocMetrics({
+        doc: {
+          scrollWidth: 400,
+          scrollHeight: 300,
+          offsetWidth: 380,
+          offsetHeight: 280,
+          clientWidth: 360,
+          clientHeight: 260,
+        },
+        body: {
+          scrollWidth: 350,
+          scrollHeight: 250,
+          offsetWidth: 340,
+          offsetHeight: 240,
+          clientWidth: 330,
+          clientHeight: 230,
+        },
+        se: {
+          scrollWidth: 370,
+          scrollHeight: 270,
+          offsetWidth: 365,
+          offsetHeight: 265,
+          clientWidth: 355,
+          clientHeight: 255,
+        },
+      });
+
+      // Act
+      const res = measureContentSize();
+
+      // Assert: max of baseline widths/heights: width=400, height=300
+      expect(res).toEqual({ width: 400, height: 300 });
+
+      // Cleanup
+      spy.mockRestore();
+    });
+
+    it('uses max of scroll totals when scrollable element dominates', () => {
+      // Arrange baseline small
+      setDocMetrics({
+        doc: {
+          scrollWidth: 500,
+          scrollHeight: 400,
+          offsetWidth: 480,
+          offsetHeight: 380,
+          clientWidth: 460,
+          clientHeight: 360,
+        },
+      });
+      // Element with huge scroll area (dominates)
+      makeEl({ left: 0, top: 0, right: 200, bottom: 100 }, { w: 1800, h: 1600 });
+
+      // Act
+      const res = measureContentSize();
+
+      // Assert: width=1800, height=1600 (from maxScrollW/H)
+      expect(res).toEqual({ width: 1800, height: 1600 });
+    });
+
+    it('includes visualViewport offsets in bbox computation when available', () => {
+      // Arrange: small baseline, one element whose bbox is shifted by visualViewport
+      setDocMetrics({
+        doc: {
+          scrollWidth: 300,
+          scrollHeight: 200,
+          offsetWidth: 300,
+          offsetHeight: 200,
+          clientWidth: 300,
+          clientHeight: 200,
+        },
+      });
+      // element rect (10,20)-(210,120) → width=200, height=100
+      makeEl({ left: 10, top: 20, right: 210, bottom: 120 });
+      // visual viewport offsets
+      mockVisualViewport(50, 100);
+
+      // Act
+      const res = measureContentSize();
+
+      // Assert:
+      // bbox width = (210+50) - (10+50) = 200
+      // bbox height = (120+100) - (20+100) = 100
+      // max(base 300x200, scroll 0x0, bbox 200x100) → 300x200
+      expect(res).toEqual({ width: 300, height: 200 });
+    });
+
+    it('falls back to window.scrollX/scrollY when visualViewport is not available', () => {
+      // Arrange: remove visualViewport and set scroll fallback
+      mockVisualViewport(undefined, undefined);
+      mockScrollOffsets(30, 40);
+
+      setDocMetrics({
+        doc: {
+          scrollWidth: 100,
+          scrollHeight: 90,
+          offsetWidth: 100,
+          offsetHeight: 90,
+          clientWidth: 100,
+          clientHeight: 90,
+        },
+      });
+      // Two elements spanning visually with offsets included
+      makeEl({ left: 0, top: 0, right: 150, bottom: 50 }); // width 150, height 50
+      makeEl({ left: 200, top: 120, right: 260, bottom: 200 }); // expands right/bottom further
+
+      // Act
+      const res = measureContentSize();
+
+      // Assert:
+      // With offset (30,40), minLeft = 0+30=30, maxRight = 260+30=290 → bboxW = 260
+      // minTop = 0+40=40, maxBottom = 200+40=240 → bboxH = 200
+      // max(base 100x90, scroll 0x0, bbox 260x200) → 260x200
+      expect(res).toEqual({ width: 260, height: 200 });
+    });
+  });
+});

--- a/tests/unit-pure/common/messages.test.ts
+++ b/tests/unit-pure/common/messages.test.ts
@@ -11,8 +11,10 @@ describe('common/messages', () => {
         'RENDER',
         'CLEAR',
         'HOVER',
+        'MEASURE_SIZE',
         'SELECTED',
         'MISSING_IDS',
+        'CONTENT_SIZE_RESULT',
         'ACTIVE_TAB_CHANGED',
       ];
 


### PR DESCRIPTION
### Summary
Full-page screenshots were truncated on pages where scrolling was applied to an inner container (e.g., `<main>`) instead of `<body>`.
This PR fixes the issue by measuring the true content width/height from the content script and using that size for full-page capture.


### Background / Problem
- CDP `Page.getLayoutMetrics` can under-report total content height when the scroll container is not `<body>`.
- As a result, our “full screen” capture missed content below the fold on layouts using `overflow: auto` on inner elements.

### What I changed
- Added a content-side measurement function that returns the effective content size (width/height) irrespective of which element owns scrolling.
- Updated the capture flow to prefer the content-reported size for full-page captures.
- Kept viewport-only capture behavior unchanged.